### PR TITLE
Fix backslashes on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var through      = require('through2');
 var fs           = require('fs');
 var request      = require('request');
+var slash        = require('slash');
 var gutil        = require('gulp-util');
 var PluginError  = gutil.PluginError;
 
@@ -61,7 +62,7 @@ module.exports = function (packageFile, opt) {
 				},
 				formData: {
 					file:  fs.createReadStream(file.path),
-					name: (!!opt.DOMAIN ? opt.DOMAIN : '') + '/' + file.relative
+					name: (!!opt.DOMAIN ? opt.DOMAIN : '') + '/' + slash(file.relative)
 				}
 			}, cb);
 		}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "gulp-util": "^3.0.6",
     "request": "^2.62.0",
+    "slash": "^1.0.0",
     "through2": "^2.0.0"
   }
 }


### PR DESCRIPTION
After the domain, artifact names had backslashes when using this plugin on Windows.

Thanks for the plugin! :+1: 
