### PR TITLE
Update to allow releases with commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ var opt = {
   API_URL: 'https://app.getsentry.com/api/0/projects/ORGANIZATION/PROJECT/',
   API_KEY: 'MY_LONG_AUTH_TOKEN',
   debug: true,
-  versionPrefix: '' // Append before the version number in package.json
+  versionPrefix: '', // Append before the version number in package.json
+  repository: 'owner-name/repo-name', // optional
+  commit: '2da95dfb052f477380608d59d32b4ab9', // optional
+  previousCommit: '1e6223108647a7bfc040ef0ca5c92f68ff0dd993' // optional
 }
 
 // Pull the version from the package.json file.


### PR DESCRIPTION
Thanks for the plugin, I have been using it for the past 6 months or so.
I recently realised that you can now add commits to your releases so that Sentry does some smart matching between stack trace and the git history to know when an issue was introduced.

Unfortunately this is done on an other release endpoint as the one used in this project. I therefore made an update so that we can now benefit from this new feature.

Link to the Sentry doc: https://docs.sentry.io/learn/releases/#releases-are-better-with-commits

Let me know your thoughts,
Thanks