### PR TITLE
Change domain default to `~`

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ module.exports = function (packageFile, opt) {
 							filename: file.relative
 						}
 					},
-					name: (opt.DOMAIN || '') + '/' + slash(file.relative)
+					name: (opt.DOMAIN || '~') + '/' + slash(file.relative)
 				}
 			}, cb);
 		}


### PR DESCRIPTION
After this plugin wasn't working for me, I figured out that the default for domains (sentry calls this *url prefix*) should be `~`.  See https://github.com/getsentry/sentry-cli/blob/master/docs/releases.rst#upload-source-maps